### PR TITLE
added Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:alpine
+
+RUN apk add --no-cache git upx
+
+WORKDIR /fargate
+
+ADD go.mod .
+RUN go mod download
+
+ADD . /fargate
+RUN go build -ldflags="-s -w"
+RUN upx --brute fargate
+
+FROM alpine
+
+RUN apk add --no-cache ca-certificates
+
+COPY --from=0 /fargate/fargate /usr/local/bin/


### PR DESCRIPTION
Would be nice to have an official docker image for ci jobs on dockerhub with [autobuild](https://docs.docker.com/docker-hub/builds/).

Got the size down to ~10mb using upx: https://blog.filippo.io/shrink-your-go-binaries-with-this-one-weird-trick/.
