### PR TITLE
display correct version. Fixes #90

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.3.2 (2019-05-31)
+
+### Bug Fixes
+
+- Display the correct version using `--version`. See https://github.com/jpignata/fargate/issues/90.
+- Updated downloads section in documentation to point to this version `0.3.2`.
+
 ## 0.3.1 (2019-05-09)
 
 ### Enhancements

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	version = "0.3.0"
+	version = "0.3.2"
 
 	defaultClusterName = "fargate"
 	defaultRegion      = "us-east-1"

--- a/doc/website/index.html
+++ b/doc/website/index.html
@@ -231,7 +231,7 @@ $ fargate service create myotherservice --lb mylb --port 80 --rule PATH=/myother
             <div class="card-body">
               <h4 class="card-title"><img class="icon" src="apple.png"> macOS</h4>
               <p class="card-text">
-                <a href="https://github.com/jpignata/fargate/releases/download/v0.3.0/fargate-0.3.0-darwin-amd64.zip">64-bit</a>
+                <a href="https://github.com/jpignata/fargate/releases/download/v0.3.2/fargate-0.3.2-darwin-amd64.zip">64-bit</a>
               </p>
             </div>
           </div>
@@ -239,9 +239,9 @@ $ fargate service create myotherservice --lb mylb --port 80 --rule PATH=/myother
             <div class="card-body">
               <h4 class="card-title"><img class="icon" src="linux.png"> Linux</h4>
               <p class="card-text">
-                <a href="https://github.com/jpignata/fargate/releases/download/v0.3.0/fargate-0.3.0-linux-amd64.zip">64-bit</a> |
-                <a href="https://github.com/jpignata/fargate/releases/download/v0.3.0/fargate-0.3.0-linux-386.zip">32-bit</a> |
-                <a href="https://github.com/jpignata/fargate/releases/download/v0.3.0/fargate-0.3.0-linux-arm.zip">Arm</a>
+                <a href="https://github.com/jpignata/fargate/releases/download/v0.3.2/fargate-0.3.2-linux-amd64.zip">64-bit</a> |
+                <a href="https://github.com/jpignata/fargate/releases/download/v0.3.2/fargate-0.3.2-linux-386.zip">32-bit</a> |
+                <a href="https://github.com/jpignata/fargate/releases/download/v0.3.2/fargate-0.3.2-linux-arm.zip">Arm</a>
               </p>
             </div>
           </div>


### PR DESCRIPTION
- Display the correct version using `--version`. See https://github.com/jpignata/fargate/issues/86 https://github.com/jpignata/fargate/issues/90.
- Updated downloads section in documentation to point to this version `0.3.2`.

**TO DO**: After this is merged, just publish a `0.3.2` release.