### PR TITLE
Support for profiles defined in .aws/config with MFA authentication.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,6 +14,7 @@ import (
 	ECS "github.com/awslabs/fargatecli/ecs"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh/terminal"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 )
 
 const (
@@ -99,7 +100,8 @@ CloudWatch Logs, and Amazon Route 53 into an easy-to-use CLI.`,
 			} else if envAwsRegion != "" {
 				region = envAwsRegion
 			} else {
-				if sess = session.Must(session.NewSession()); *sess.Config.Region != "" {
+				if sess = session.Must(session.NewSessionWithOptions(session.Options { 
+					AssumeRoleTokenProvider: stscreds.StdinTokenProvider})); *sess.Config.Region != "" {
 					region = *sess.Config.Region
 				} else {
 					region = defaultRegion
@@ -116,7 +118,10 @@ CloudWatch Logs, and Amazon Route 53 into an easy-to-use CLI.`,
 		}
 
 		sess = session.Must(
-			session.NewSession(config),
+			session.NewSessionWithOptions(session.Options {
+				AssumeRoleTokenProvider: stscreds.StdinTokenProvider,
+				Config: *config,
+			}),
 		)
 
 		_, err := sess.Config.Credentials.Get()


### PR DESCRIPTION
*Issue #, if available:* 17

*Description of changes:*
Support for profiles requiring MFA authentication, e.g.

% AWS_DEFAULT_PROFILE=my-profile-name AWS_SDK_LOAD_CONFIG=true ./fargate task list

will now ask MFA code if that has been enabled for my-profile-name defined in .aws/config

(but now reading through all the comments I realize since there is no MFA caching in GO SDK this doesn't provide very good user experince)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
