### PR TITLE
Allow setting environment variables which contain commas

### DIFF
--- a/cmd/service_env_set.go
+++ b/cmd/service_env_set.go
@@ -24,7 +24,7 @@ func (o *ServiceEnvSetOperation) SetEnvVars(inputEnvVars []string) {
 var flagServiceEnvSetEnvVars []string
 
 var serviceEnvSetCmd = &cobra.Command{
-	Use:   "set --env <key=value> [--env <key=value] ...",
+	Use:   "set --env <key=value> [--env <key=value>] ...",
 	Short: "Set environment variables",
 	Long: `Set environment variables
 
@@ -43,7 +43,7 @@ At least one environment variable must be specified via the --env flag. Specify
 }
 
 func init() {
-	serviceEnvSetCmd.Flags().StringSliceVarP(&flagServiceEnvSetEnvVars, "env", "e", []string{}, "Environment variables to set [e.g. KEY=value]")
+	serviceEnvSetCmd.Flags().StringArrayVarP(&flagServiceEnvSetEnvVars, "env", "e", []string{}, "Environment variables to set [e.g. KEY=value]")
 
 	serviceEnvCmd.AddCommand(serviceEnvSetCmd)
 }


### PR DESCRIPTION
*Issue #, if available:*
[40](https://github.com/awslabs/fargatecli/issues/40)
*Description of changes:*
I have just ported the [suggested change](https://github.com/awslabs/fargatecli/issues/40#issuecomment-495192777): using `StringArrayVarP` instead of `StringSliceVarP`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
