### PR TITLE
fixes the current circleci red status

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
       - run: git config --global user.name CircleCI
 
       - run: go get -u github.com/golang/dep/cmd/dep
+      - run: dep init
       - run: dep ensure
 
       - run: make test


### PR DESCRIPTION
*Description of changes:*

Your pipeline is red right now.... it is very easy to solve. Using an example is easier to see:
```
docker run -ti circleci/golang:1.10 bash
Unable to find image 'circleci/golang:1.10' locally
1.10: Pulling from circleci/golang
741437d97401: Pull complete
34d8874714d7: Pull complete
0a108aa26679: Pull complete
7f0334c36886: Pull complete
d35724ed4672: Pull complete
c0eaf021aeaf: Pull complete
d3d9c96611f1: Pull complete
98b279cde77c: Pull complete
1c718501bba2: Pull complete
78cb342acd91: Pull complete
c834f67c8e89: Pull complete
5b3b7381a1a7: Pull complete
e758623994b1: Pull complete
3426d158abc3: Pull complete
3a42669b66d1: Pull complete
89220128ae44: Pull complete
a8f96c478a5b: Pull complete
Digest: sha256:75983d7d418a9436186a1a33d33fbfbc4a56715ee50c8189d0c9259d9df945fd
Status: Downloaded newer image for circleci/golang:1.10

circleci@a8876acb88a9:/go$ go get github.com/awslabs/fargatecli

circleci@a8876acb88a9:/go$ cd $GOPATH/src/github.com/awslabs/fargatecli
circleci@a8876acb88a9:/go/src/github.com/awslabs/fargatecli$ dep ensure
could not find project Gopkg.toml, use dep init to initiate a manifest
circleci@a8876acb88a9:/go/src/github.com/awslabs/fargatecli$ dep init
  Locking in master (29b5707) for transitive dep golang.org/x/sys
  Using ^2.2.2 as constraint for direct dep github.com/kyokomi/emoji
  Locking in v2.2.2 (cab09f7) for direct dep github.com/kyokomi/emoji
  Using ^0.5.4 as constraint for direct dep github.com/hashicorp/golang-lru
  Locking in v0.5.4 (14eae34) for direct dep github.com/hashicorp/golang-lru
  Using master as constraint for direct dep golang.org/x/crypto
  Locking in master (729f1e8) for direct dep golang.org/x/crypto
  Locking in v1.0.5 (2e9d26c) for transitive dep github.com/spf13/pflag
  Locking in v0.0.12 (7b513a9) for transitive dep github.com/mattn/go-isatty
  Locking in  (c2b33e84) for transitive dep github.com/jmespath/go-jmespath
  Using master as constraint for direct dep golang.org/x/time
  Locking in master (89c76fb) for direct dep golang.org/x/time
  Locking in v1.0 (76626ae) for transitive dep github.com/inconshreveable/mousetrap
  Using ^1.0.0 as constraint for direct dep github.com/spf13/cobra
  Locking in v1.0.0 (a684a6d) for direct dep github.com/spf13/cobra
  Using ^1.4.3 as constraint for direct dep github.com/golang/mock
  Locking in v1.4.3 (3a35fb6) for direct dep github.com/golang/mock
  Locking in v0.1.6 (68e95eb) for transitive dep github.com/mattn/go-colorable
  Using ^1.30.14 as constraint for direct dep github.com/aws/aws-sdk-go
  Locking in v1.30.14 (ac56338) for direct dep github.com/aws/aws-sdk-go
  Using master as constraint for direct dep github.com/mgutz/ansi
  Locking in master (9520e82) for direct dep github.com/mgutz/ansi
circleci@a8876acb88a9:/go/src/github.com/awslabs/fargatecli$ dep ensure
circleci@a8876acb88a9:/go/src/github.com/awslabs/fargatecli$ echo $?
0
```

So, I did a tiny fix if you are interested. 



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
