### PR TITLE
Fixed Dockerfile, dockerized devx, added more doc

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,86 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+FROM golang:1
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
+# property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
+# will be updated to match your local UID/GID (when using the dockerFile property).
+# See https://aka.ms/vscode-remote/containers/non-root-user for details.
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Configure apt, install packages and tools
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
+    #
+    # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
+    && apt-get -y install git openssh-client zip vim less iproute2 procps lsb-release \
+    #
+    # SSL dependencies
+    && apt-get -y install apt-transport-https ca-certificates gnupg2 \
+    #
+    # Build Go tools w/module support
+    && mkdir -p /tmp/gotools \
+    && cd /tmp/gotools \
+    && GOPATH=/tmp/gotools GO111MODULE=on go get -v golang.org/x/tools/gopls@latest 2>&1 \
+    && GOPATH=/tmp/gotools GO111MODULE=on go get -v \
+        honnef.co/go/tools/...@latest \
+        golang.org/x/tools/cmd/gorename@latest \
+        golang.org/x/tools/cmd/goimports@latest \
+        golang.org/x/tools/cmd/guru@latest \
+        golang.org/x/lint/golint@latest \
+        github.com/mdempsky/gocode@latest \
+        github.com/cweill/gotests/...@latest \
+        github.com/haya14busa/goplay/cmd/goplay@latest \
+        github.com/sqs/goreturns@latest \
+        github.com/josharian/impl@latest \
+        github.com/davidrjenni/reftools/cmd/fillstruct@latest \
+        github.com/uudashr/gopkgs/v2/cmd/gopkgs@latest  \
+        github.com/ramya-rao-a/go-outline@latest  \
+        github.com/acroca/go-symbols@latest  \
+        github.com/godoctor/godoctor@latest  \
+        github.com/rogpeppe/godef@latest  \
+        github.com/zmb3/gogetdoc@latest \
+        github.com/fatih/gomodifytags@latest  \
+        github.com/mgechev/revive@latest  \
+        github.com/go-delve/delve/cmd/dlv@latest 2>&1 \
+    #
+    # Build Go tools w/o module support
+    && GOPATH=/tmp/gotools go get -v github.com/alecthomas/gometalinter 2>&1 \
+    #
+    # Build gocode-gomod
+    && GOPATH=/tmp/gotools go get -x -d github.com/stamblerre/gocode 2>&1 \
+    && GOPATH=/tmp/gotools go build -o gocode-gomod github.com/stamblerre/gocode \
+    #
+    # Install Go tools
+    && mv /tmp/gotools/bin/* /usr/local/bin/ \
+    && mv gocode-gomod /usr/local/bin/ \
+    #
+    # Install golangci-lint
+    && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin 2>&1 \
+    #
+    # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
+    && groupadd --gid $USER_GID $USERNAME \
+    && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    # [Optional] Add sudo support
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME \
+    #
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/* /tmp/gotools
+
+# Update this to "on" or "off" as appropriate
+ENV GO111MODULE=auto
+
+# Switch back to dialog for any ad-hoc use of apt-get
+ENV DEBIAN_FRONTEND=dialog

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.117.1/containers/go
+{
+	"name": "Go",
+	"dockerFile": "Dockerfile",
+	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined", "-v", "${env:HOME}${env:USERPROFILE}/.aws:/root/.aws", "-v", "${env:HOME}${env:USERPROFILE}/.aws:/home/vscode/.aws" ],
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"go.gopath": "/go",
+	},
+
+	"containerEnv": {
+		"AWS_SDK_LOAD_CONFIG": "1", // enable SharedConfigEnable for fargate cli (https://docs.aws.amazon.com/sdk-for-go/api/aws/session/#hdr-Sessions_options_from_Shared_Config)
+	},
+	
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"ms-vscode.go",
+		"eamodio.gitlens",
+		"donjayamanne.githistory",
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "go mod download",
+
+	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "vscode"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,25 @@ email and Google Hangouts at john@pignata.com.
 - For cross-building for all supported platforms, run `make dist` which builds
   binaries for darwin (64-bit) and linux (Arm, 32-bit, 64-bit).
 
+## Developing using Docker
+
+### Minimum requirement
+
+1. Visual Studio Code
+2. Remote - Containers extension for Visual Studio Code
+3. Docker
+
+Clone the current repository.  Open the folder with VSCode Remote - Containers extension.
+
+Note: The remote container has *AWS_SDK_LOAD_CONFIG* environment variable set to use AWS CLI configuration.
+
+Open a terminal in VS Code to execute the cli.
+
+```console
+go run main.go --version
+```
+
+
 ## Licensing
 
 This project is released under the [Apache 2.0 license][apache].

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,11 @@ RUN go mod download
 
 ADD . /fargate
 RUN go build -ldflags="-s -w"
-RUN upx --brute fargate
+RUN upx --brute -o fargate fargatecli
 
 FROM alpine
 
 RUN apk add --no-cache ca-certificates
 
-COPY --from=0 /fargate/fargate /usr/local/bin/
+COPY --from=0 /fargate/fargate /usr/local/bin/fargate
+ENTRYPOINT [ "/usr/local/bin/fargate" ]

--- a/README.md
+++ b/README.md
@@ -7,6 +7,29 @@
 
 [![fargate CLI screencast](http://img.youtube.com/vi/P6iY6ovhbfc/0.jpg)](http://www.youtube.com/watch?v=P6iY6ovhbfc)
 
+## Installation
+
+### Latest release builds
+
+Download and unzip specific platform releases from [Releases](https://github.com/awslabs/fargatecli/releases).
+
+### Latest changes (unstable)
+
+With Docker installed, run the following:
+
+### Windows
+
+```console
+docker build -t local/fargatecli https://github.com/awslabs/fargatecli.git
+docker run --rm -it -e "AWS_SDK_LOAD_CONFIG=1" -v %USERPROFILE%/.aws:/root/.aws -v %cd%:/aws -w /aws local/fargatecli --version
+```
+
+### Linux / MacOS
+```console
+docker build -t local/fargatecli https://github.com/awslabs/fargatecli.git
+docker run --rm -it -e "AWS_SDK_LOAD_CONFIG=1" -v $HOME/.aws:/root/.aws -v $PWD:/aws -w /aws local/fargatecli --version
+```
+
 ## Usage
 
 ### Configuration
@@ -14,8 +37,17 @@
 #### Region
 
 By default, fargate uses *us-east-1*. The CLI accepts a --region parameter and
-will honor *AWS_REGION* and *AWS_DEFAULT_REGION* environment settings. Note that
-specifying a region where all required services aren't available will return an
+will honor *AWS_REGION* and *AWS_DEFAULT_REGION* environment settings.
+
+The CLI also makes use of the AWS CLI SDK and supports the [Shared Config](https://docs.aws.amazon.com/sdk-for-go/api/aws/session/#hdr-Sessions_options_from_Shared_Config) of the [AWS CLI](https://aws.amazon.com/cli/).  If the *AWS_SDK_LOAD_CONFIG* environment variable is set to a truthy value the Session will be created from the configuration values from the shared config (`~/.aws/config`) and shared credentials (`~/.aws/credentials`) files.
+
+```console
+> aws configure #set credentials and region here
+...
+> set AWS_SDK_LOAD_CONFIG=1
+```
+
+Note that specifying a region where all required services aren't available will return an
 error.
 
 See the [Region Table][region-table] for a breakdown of what services are


### PR DESCRIPTION
*Issue #, if available:*
1. I've experienced issues following the tutorial to set up new running task or creating new service via fargate cli.  The documents mentioned that the AWS SDK is utilized, but did not mention how the `.aws/config` file can be leveraged.  It wasn't clear that a variable has to be set, unless you read through the AWS SDK documentation in detail.
2. There is no instructions for installing the CLI, and also to use the latest code changes if needed.
3. Dockerfile is not building.


*Description of changes:*
- As best practices, I have added support for devcontaine to support VSCode development container experience..  This would also bring us closer to CodeSpace compatibility once Github releases that capability (feature to spin up development environment within Github).
- Fixed Dockerfile which fails to build.
- Added documentation for contribution as well as integration with AWS
CLI config file
- Made Dockerfile such that it can be run using Docker run without additional parameters.
- Added documentation for installation using various methods.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
