### PR TITLE
Create default SG for Task Run and Service Create

### DIFF
--- a/cmd/vpc_operation.go
+++ b/cmd/vpc_operation.go
@@ -31,27 +31,11 @@ func (o *vpcOperation) setSecurityGroupIDs(securityGroupIDs []string) {
 }
 
 func (o *vpcOperation) setDefaultSecurityGroupID() error {
-	o.output.Debug("Finding default security group [API=ec2 Action=DescribeSecurityGroups]")
-	defaultSecurityGroupID, err := o.ec2.GetDefaultSecurityGroupID()
 
+	// setting of default security group id is delegated to the ec2 module
+	defaultSecurityGroupID, err := o.ec2.SetDefaultSecurityGroupID()
 	if err != nil {
 		return err
-	}
-
-	if defaultSecurityGroupID == "" {
-		o.output.Debug("Creating default security group [API=ec2 Action=CreateSecurityGroup]")
-		defaultSecurityGroupID, err = o.ec2.CreateDefaultSecurityGroup()
-
-		if err != nil {
-			return err
-		}
-
-		o.output.Debug("Created default security group [ID=%s]", defaultSecurityGroupID)
-
-		o.output.Debug("Configuring default security group [API=ec2 Action=AuthorizeSecurityGroupIngress]")
-		if err := o.ec2.AuthorizeAllSecurityGroupIngress(defaultSecurityGroupID); err != nil {
-			return err
-		}
 	}
 
 	o.securityGroupIDs = []string{defaultSecurityGroupID}

--- a/ec2/main.go
+++ b/ec2/main.go
@@ -16,6 +16,7 @@ type Client interface {
 	GetDefaultSecurityGroupID() (string, error)
 	GetDefaultSubnetIDs() ([]string, error)
 	GetSubnetVPCID(string) (string, error)
+	SetDefaultSecurityGroupID() (string, error)
 }
 
 // SDKClient implements access to EC2 via the AWS SDK.

--- a/ec2/mock/client/client.go
+++ b/ec2/mock/client/client.go
@@ -105,3 +105,18 @@ func (mr *MockClientMockRecorder) GetSubnetVPCID(arg0 interface{}) *gomock.Call 
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubnetVPCID", reflect.TypeOf((*MockClient)(nil).GetSubnetVPCID), arg0)
 }
+
+// SetDefaultSecurityGroupID mocks base method
+func (m *MockClient) SetDefaultSecurityGroupID() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetDefaultSecurityGroupID")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SetDefaultSecurityGroupID indicates an expected call of SetDefaultSecurityGroupID
+func (mr *MockClientMockRecorder) SetDefaultSecurityGroupID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDefaultSecurityGroupID", reflect.TypeOf((*MockClient)(nil).SetDefaultSecurityGroupID))
+}


### PR DESCRIPTION
*Issue #, if available:*
1. Fargate CLI currently does not check if the default security groups exist.  It polls for the `fargate-default` security group.  For fresh AWS accounts, there is no such SG. This results in a `nil` being returned.  The CLI continues down this path to register the task/service with the SG, resulting in the following error message
2. To reproduce this error, go to the [AWS Console -> EC2> Security groups](https://console.aws.amazon.com/ec2/v2/home?#SecurityGroups:). If `fargate-default` is available, select it and remove it.
3. In a terminal window, do the following: 

```console
> fargate task run web --image nginx:latest -v
...
[!] Could not run ECS task
InvalidParameterException: security group cannot be blank.
        status code: 400, request id: ce47d313-0784-4dfa-8c1b-f359f02693b0
```

*Description of changes:*
- Added `SetDefaultSecurityGroupID()` call to check for default security groups for run task and
create service.
- Run task and create service creates default security group if default
security group does not exist.
- Similar function in` vpc_operation.go` is refactored into EC2 client and
shared with `service_create.go` and `task_run.go`.
- Added console logs in EC2 client, service_create.go, task_run.go.
- Unit tests for refactored code. Increased EC2 module code coverage by _10%_.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
