### PR TITLE
chore: use String() instead of fmt.Sprintf

### DIFF
--- a/cmd/lb_list.go
+++ b/cmd/lb_list.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"sync"
 
@@ -44,7 +43,7 @@ func (o lbListOperation) execute() {
 				Titleize(loadBalancer.Type),
 				Titleize(loadBalancer.Status),
 				loadBalancer.DNSName,
-				fmt.Sprintf("%s", loadBalancer.Listeners),
+				loadBalancer.Listeners.String(),
 			},
 		)
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
